### PR TITLE
Gave `os-release` priority as an OS identification data file

### DIFF
--- a/install.py
+++ b/install.py
@@ -30,11 +30,12 @@ def check_root() -> None:
 
 def check_distro():
     cwd_cont = os.listdir("/etc")
-    release_file_path = ""
-    for i in cwd_cont:
-        if i.endswith("-release") and os.path.isfile(f"/etc/{i}"):
-            release_file_path = f"/etc/{i}"
-            break
+    release_file_path = '/etc/os-release' if 'os-release' in cwd_cont else ''
+    if not release_file_path:
+        for i in cwd_cont:
+            if i.endswith("-release") and os.path.isfile(f"/etc/{i}"):
+                release_file_path = f"/etc/{i}"
+                break
     
     if not release_file_path:
         raise Exception("Release file not found")


### PR DESCRIPTION
Most distributions use systemd which has os-release as the file containing [OS identification data](https://www.freedesktop.org/software/systemd/man/os-release.html). Therefore, I believe using the data it contains is a priority, then searching for other files can be a secondary task. In distributions like arch linux which contains another file called arch-release. a totally empty file that is there just to let programs [know that the distribution is arch](https://bbs.archlinux.org/viewtopic.php?id=86414).
The existence of such files will cause problems such as the one mentioned in #17 
Therefore, I believe giving priority to os-release before other files ending with "-release" is a good move to make the installation script work with a wider variety of distributions 